### PR TITLE
Coding standard updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"phpstan/phpstan": "^0.12",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
-		"spaze/coding-standard": "^0.0.4"
+		"spaze/coding-standard": "^0.0"
 	},
 	"scripts": {
 		"lint": "vendor/bin/parallel-lint --colors src/ tests/",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 	"scripts": {
 		"lint": "vendor/bin/parallel-lint --colors src/ tests/",
 		"phpcs": "vendor/bin/phpcs src/ tests/",
+		"cs-fix": "vendor/bin/phpcbf src/ tests/",
 		"phpstan": "vendor/phpstan/phpstan/phpstan --ansi analyse --configuration phpstan.neon",
 		"tester": "vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 tests/",
 		"test": [

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require-dev": {
 		"nette/tester": "^2.0",
 		"nette/bootstrap": "^3.0",
-		"phpstan/phpstan": "^0.12",
+		"phpstan/phpstan": "^1.2",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
 		"spaze/coding-standard": "^0.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,5 +5,8 @@
 	<arg name="colors"/>
 	<arg value="s"/>
 	<arg value="p"/>
-	<rule ref="vendor/spaze/coding-standard/src/ruleset.xml"/>
+	<rule ref="vendor/spaze/coding-standard/src/ruleset.xml">
+		<exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall" />
+		<exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration" />
+	</rule>
 </ruleset>

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,13 +23,13 @@ class Config
 	/** @var GeneratorInterface|null */
 	private $nonceGenerator;
 
-	/** @var array<string, array<string, string|array<integer, string>>> */
+	/** @var array<string, array<string, (string|array<int, string>)>> */
 	private $policy = [];
 
-	/** @var array<string, array<string, array<integer, string>>> */
+	/** @var array<string, array<string, array<int, string>>> */
 	private $snippets = [];
 
-	/** @var array<integer, string> */
+	/** @var array<int, string> */
 	private $currentSnippets = [];
 
 	/** @var array<string, string> */
@@ -43,7 +43,7 @@ class Config
 
 
 	/**
-	 * @param array<string, array<string, string|array<integer, string>>> $policy
+	 * @param array<string, array<string, (string|array<int, string>)>> $policy
 	 * @return self
 	 */
 	public function setPolicy(array $policy): self
@@ -56,7 +56,7 @@ class Config
 
 
 	/**
-	 * @param array<string, array<string, array<integer, string>>> $snippets
+	 * @param array<string, array<string, array<int, string>>> $snippets
 	 * @return self
 	 */
 	public function setSnippets(array $snippets): self
@@ -67,7 +67,7 @@ class Config
 
 
 	/**
-	 * @return array<string, array<string, array<integer, string>>>
+	 * @return array<string, array<string, array<int, string>>>
 	 */
 	public function getSnippets(): array
 	{
@@ -102,8 +102,8 @@ class Config
 
 
 	/**
-	 * @param array<string, string|array<integer, string>> $currentPolicy
-	 * @param array<integer, string> $parentKeys
+	 * @param array<string, (string|array<int, string>)> $currentPolicy
+	 * @param array<int, string> $parentKeys
 	 * @return array<string, array<string, string>>
 	 */
 	private function mergeExtends(array $currentPolicy, array $parentKeys): array
@@ -144,7 +144,7 @@ class Config
 
 	/**
 	 * @param string $name
-	 * @param array<integer, string> $sources
+	 * @param array<int, string> $sources
 	 */
 	private function addDirective(string $name, array $sources): void
 	{


### PR DESCRIPTION
- Newer PHPStan
- Newer coding standard (which adds trailing comma rules which need to be excluded because this still supports PHP 7.1)
- Short type hints for `int` and `bool` required by the newer coding standard