### PR TITLE
Support `Content-Security-Policy-Report-Only` (CSPRO) policies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 	"require": {
 		"php": "^7.1 || ^8.0",
 		"nette/di": "^3.0",
+		"nette/schema": "^1.2",
 		"spaze/nonce-generator": "^3.0.2"
 	},
 	"autoload": {

--- a/src/Bridges/Nette/ConfigExtension.php
+++ b/src/Bridges/Nette/ConfigExtension.php
@@ -22,24 +22,19 @@ class ConfigExtension extends CompilerExtension
 
 	public function getConfigSchema(): Schema
 	{
+		$expectPolicies = Expect::arrayOf(
+			Expect::arrayOf(
+				Expect::anyOf(
+					Expect::listOf(Expect::string()),
+					Expect::string()
+				)->castTo('array')
+			)
+		);
 		return Expect::structure([
 			'supportLegacyBrowsers' => Expect::bool()->default(false),
-			'snippets' => Expect::arrayOf(
-				Expect::arrayOf(
-					Expect::anyOf(
-						Expect::listOf(Expect::string()),
-						Expect::string()
-					)
-				)
-			)->default([]),
-			'policies' => Expect::arrayOf(
-				Expect::arrayOf(
-					Expect::anyOf(
-						Expect::listOf(Expect::string()),
-						Expect::string()
-					)->castTo('array')
-				)
-			)->required(),
+			'snippets' => (clone $expectPolicies)->default([]),
+			'policies' => (clone $expectPolicies)->required(),
+			'policiesReportOnly' => (clone $expectPolicies)->default([]),
 		]);
 	}
 
@@ -51,6 +46,7 @@ class ConfigExtension extends CompilerExtension
 		$cspConfig = $builder->addDefinition($this->prefix('config'))
 			->setClass('Spaze\ContentSecurityPolicy\Config')
 			->addSetup('setPolicy', [$this->config->policies])
+			->addSetup('setPolicyReportOnly', [$this->config->policiesReportOnly])
 			->addSetup('setSnippets', [$this->config->snippets]);
 
 		if ($this->config->supportLegacyBrowsers) {

--- a/src/Bridges/Nette/ConfigExtension.php
+++ b/src/Bridges/Nette/ConfigExtension.php
@@ -44,7 +44,7 @@ class ConfigExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		$cspConfig = $builder->addDefinition($this->prefix('config'))
-			->setClass('Spaze\ContentSecurityPolicy\Config')
+			->setType('Spaze\ContentSecurityPolicy\Config')
 			->addSetup('setPolicy', [$this->config->policies])
 			->addSetup('setPolicyReportOnly', [$this->config->policiesReportOnly])
 			->addSetup('setSnippets', [$this->config->snippets]);

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\ContentSecurityPolicy;
 
-use Nette\DI\Config\Helpers;
+use Nette\Schema\Helpers;
 use Spaze\NonceGenerator\GeneratorInterface;
 
 /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,6 +10,7 @@ use Spaze\NonceGenerator\GeneratorInterface;
  * ContentSecurityPolicy\Config service.
  *
  * @author Michal Špaček
+ * @phpstan-type PolicyArray array<string, array<string, string|array<int, string>>>
  */
 class Config
 {
@@ -23,10 +24,13 @@ class Config
 	/** @var GeneratorInterface|null */
 	private $nonceGenerator;
 
-	/** @var array<string, array<string, (string|array<int, string>)>> */
+	/** @var PolicyArray */
 	private $policy = [];
 
-	/** @var array<string, array<string, array<int, string>>> */
+	/** @var PolicyArray */
+	private $policyReportOnly = [];
+
+	/** @var PolicyArray */
 	private $snippets = [];
 
 	/** @var array<int, string> */
@@ -43,7 +47,7 @@ class Config
 
 
 	/**
-	 * @param array<string, array<string, (string|array<int, string>)>> $policy
+	 * @param PolicyArray $policy
 	 * @return self
 	 */
 	public function setPolicy(array $policy): self
@@ -56,7 +60,20 @@ class Config
 
 
 	/**
-	 * @param array<string, array<string, array<int, string>>> $snippets
+	 * @param PolicyArray $policy
+	 * @return self
+	 */
+	public function setPolicyReportOnly(array $policy): self
+	{
+		foreach ($policy as $key => $sources) {
+			$this->policyReportOnly[$key] = $sources;
+		}
+		return $this;
+	}
+
+
+	/**
+	 * @param PolicyArray $snippets
 	 * @return self
 	 */
 	public function setSnippets(array $snippets): self
@@ -67,7 +84,7 @@ class Config
 
 
 	/**
-	 * @return array<string, array<string, array<int, string>>>
+	 * @return PolicyArray
 	 */
 	public function getSnippets(): array
 	{
@@ -80,13 +97,34 @@ class Config
 	 */
 	public function getHeader(string $presenter, string $action): string
 	{
+		return $this->getHeaderValue($presenter, $action, $this->policy);
+	}
+
+
+	/**
+	 * Get Content-Security-Policy-Report-Only header value.
+	 */
+	public function getHeaderReportOnly(string $presenter, string $action): string
+	{
+		return $this->getHeaderValue($presenter, $action, $this->policyReportOnly);
+	}
+
+
+	/**
+	 * @param string $presenter
+	 * @param string $action
+	 * @param PolicyArray $policy
+	 * @return string
+	 */
+	private function getHeaderValue(string $presenter, string $action, array $policy): string
+	{
 		$this->directives = [];
 
-		$configKey = $this->findConfigKey($presenter, $action);
-		if (isset($this->policy[$configKey][self::EXTENDS_KEY])) {
-			$currentPolicy = $this->mergeExtends($this->policy[$configKey], $this->policy[$configKey][self::EXTENDS_KEY]);
+		$configKey = $this->findConfigKey($presenter, $action, $policy);
+		if (isset($policy[$configKey][self::EXTENDS_KEY])) {
+			$currentPolicy = $this->mergeExtends($policy[$configKey], $policy[$configKey][self::EXTENDS_KEY], $policy);
 		} else {
-			$currentPolicy = $this->policy[$configKey];
+			$currentPolicy = $policy[$configKey];
 		}
 		foreach ($this->currentSnippets as $snippetName) {
 			foreach ($this->snippets[$snippetName] as $directive => $sources) {
@@ -102,16 +140,17 @@ class Config
 
 
 	/**
-	 * @param array<string, (string|array<int, string>)> $currentPolicy
+	 * @param array<string, string|array<int, string>> $currentPolicy
 	 * @param array<int, string> $parentKeys
+	 * @param PolicyArray $policy
 	 * @return array<string, array<string, string>>
 	 */
-	private function mergeExtends(array $currentPolicy, array $parentKeys): array
+	private function mergeExtends(array $currentPolicy, array $parentKeys, array $policy): array
 	{
 		$parentKey = current($parentKeys);
 		$currentPolicy = (array)Helpers::merge($currentPolicy, $this->policy[$parentKey]);
-		if (isset($this->policy[$parentKey][self::EXTENDS_KEY])) {
-			$currentPolicy = $this->mergeExtends($currentPolicy, $this->policy[$parentKey][self::EXTENDS_KEY]);
+		if (isset($policy[$parentKey][self::EXTENDS_KEY])) {
+			$currentPolicy = $this->mergeExtends($currentPolicy, $policy[$parentKey][self::EXTENDS_KEY], $policy);
 		}
 		unset($currentPolicy[self::EXTENDS_KEY]);
 		return $currentPolicy;
@@ -128,12 +167,18 @@ class Config
 	}
 
 
-	private function findConfigKey(string $presenter, string $action): string
+	/**
+	 * @param string $presenter
+	 * @param string $action
+	 * @param PolicyArray $policy
+	 * @return string
+	 */
+	private function findConfigKey(string $presenter, string $action, array $policy): string
 	{
 		$parts = explode(':', strtolower($presenter));
 		$parts[] = strtolower($action);
 		for ($i = count($parts) - 1; $i >= 0; $i--) {
-			if (isset($this->policy[implode(self::KEY_SEPARATOR, $parts)])) {
+			if (isset($policy[implode(self::KEY_SEPARATOR, $parts)])) {
 				break;
 			}
 			$parts[$i] = self::DEFAULT_KEY;

--- a/tests/config-with-report-only.neon
+++ b/tests/config-with-report-only.neon
@@ -1,0 +1,26 @@
+extensions:
+	contentSecurityPolicy: Spaze\ContentSecurityPolicy\Bridges\Nette\ConfigExtension
+
+contentSecurityPolicy:
+	snippets:
+		ga:
+			img-src:
+				- https://www.google-analytics.com
+	policies:
+		*.*:
+			child-src:
+				- foo
+				- bar
+			style-src:
+				- foo
+				- bar
+			script-src:
+				- foo
+				- bar
+	policiesReportOnly:
+		*.*:
+			form-action:
+				- foobar
+			script-src:
+				- waldo
+				- quux


### PR DESCRIPTION
Use `getHeaderReportOnly()` that reads config from `policiesReportOnly` config key.