### PR TITLE
Can override extended directive values

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -21,6 +21,8 @@ class Config
 
 	private const EXTENDS_KEY = '@extends';
 
+	private const OVERRIDE_FLAG = '!';
+
 	/** @var GeneratorInterface|null */
 	private $nonceGenerator;
 
@@ -199,6 +201,9 @@ class Config
 				$source = "'nonce-" . $this->nonceGenerator->getNonce() . "'";
 			}
 			$values .= $source . ' ';
+		}
+		if (isset($name[0]) && $name[0] === self::OVERRIDE_FLAG) {
+			$name = substr($name, 1);
 		}
 		$this->directives[$name] = trim("$name $values");
 	}

--- a/tests/ConfigExtensionTest.phpt
+++ b/tests/ConfigExtensionTest.phpt
@@ -63,6 +63,42 @@ class ConfigExtensionTest extends TestCase
 	}
 
 
+	public function testConfigExtendsOverride(): void
+	{
+		$this->cspConfig->addSnippet('ga');
+		Assert::noError(function (): void {
+			Assert::same("child-src foo bar; style-src foo bar; script-src 'none'; img-src https://www.google-analytics.com", $this->cspConfig->getHeader('Bar', 'foo'));
+		});
+	}
+
+
+	public function testConfigExtendsMerge(): void
+	{
+		$this->cspConfig->addSnippet('ga');
+		Assert::noError(function (): void {
+			Assert::same("child-src foo bar; style-src foo bar; script-src foo bar 'self'; img-src https://www.google-analytics.com", $this->cspConfig->getHeader('Waldo', 'fred'));
+		});
+	}
+
+
+	public function testConfigExtendsSnippetsOverride(): void
+	{
+		$this->cspConfig->addSnippet('ga-override');
+		Assert::noError(function (): void {
+			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://www.google-analytics.com https://ga.example', $this->cspConfig->getHeader('Foobar', 'baz'));
+		});
+	}
+
+
+	public function testConfigExtendsSnippetsMerge(): void
+	{
+		$this->cspConfig->addSnippet('ga');
+		Assert::noError(function (): void {
+			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://example.com https://www.google-analytics.com', $this->cspConfig->getHeader('Foobar', 'baz'));
+		});
+	}
+
+
 	public function testConfigNoReportOnly(): void
 	{
 		Assert::noError(function (): void {

--- a/tests/config.neon
+++ b/tests/config.neon
@@ -6,6 +6,10 @@ contentSecurityPolicy:
 		ga:
 			img-src:
 				- https://www.google-analytics.com
+		ga-override:
+			!img-src:
+				- https://www.google-analytics.com
+				- https://ga.example
 	policies:
 		*.*:
 			child-src:
@@ -17,3 +21,13 @@ contentSecurityPolicy:
 			script-src:
 				- foo
 				- bar
+		bar.foo:
+			@extends: *.*
+			!script-src: "'none'"
+		waldo.fred:
+			@extends: *.*
+			script-src: "'self'"
+		foobar.baz:
+			@extends: *.*
+			img-src:
+				- https://example.com


### PR DESCRIPTION
Overriding values will not be merged with the original value, instead they will override the original value.

This is not using the "Replacing operator" (which is a suffix like `key!`) available in Nette DI because it won't work in this case. That operator only works when the keys are the same like for example:

`file1.neon`:
```neon
foo:
    bar: baz
```
`file2.neon`:
```neon
foo:
    bar!: waldo
```
But this is not the case here.