### PR TITLE
Require PHP 8.2 and newest dependencies

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,11 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
-          - "7.3"
-          - "7.4"
-          - "8.0"
-          - "8.1"
           - "8.2"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -10,21 +10,21 @@
 		}
 	],
 	"require": {
-		"php": "^7.2 || ^8.0",
-		"nette/di": "^3.0",
+		"php": "^8.2",
+		"nette/di": "^3.1",
 		"nette/schema": "^1.2",
-		"spaze/nonce-generator": "^3.0.2"
+		"spaze/nonce-generator": "^3.1"
 	},
 	"autoload": {
 		"psr-4": {"Spaze\\ContentSecurityPolicy\\": "src"}
 	},
 	"require-dev": {
-		"nette/tester": "^2.0",
-		"nette/bootstrap": "^3.0",
-		"phpstan/phpstan": "^1.2",
-		"php-parallel-lint/php-parallel-lint": "^1.2",
+		"nette/tester": "^2.5",
+		"nette/bootstrap": "^3.2",
+		"phpstan/phpstan": "^1.10",
+		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
-		"spaze/coding-standard": "^1.0"
+		"spaze/coding-standard": "^1.6"
 	},
 	"scripts": {
 		"lint": "vendor/bin/parallel-lint --colors src/ tests/",

--- a/src/Bridges/Nette/ConfigExtension.php
+++ b/src/Bridges/Nette/ConfigExtension.php
@@ -8,11 +8,6 @@ use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use stdClass;
 
-/**
- * ContentSecurityPolicy\Config extension.
- *
- * @author Michal Špaček
- */
 class ConfigExtension extends CompilerExtension
 {
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -7,9 +7,6 @@ use Nette\Schema\Helpers;
 use Spaze\NonceGenerator\GeneratorInterface;
 
 /**
- * ContentSecurityPolicy\Config service.
- *
- * @author Michal Špaček
  * @phpstan-type PolicyArray array<string, array<string, array<int, string>>>
  */
 class Config
@@ -23,34 +20,30 @@ class Config
 
 	private const OVERRIDE_FLAG = '!';
 
-	/** @var GeneratorInterface|null */
-	private $nonceGenerator;
+	/** @phpstan-var PolicyArray */
+	private array $policy = [];
 
-	/** @var PolicyArray */
-	private $policy = [];
+	/** @phpstan-var PolicyArray */
+	private array $policyReportOnly = [];
 
-	/** @var PolicyArray */
-	private $policyReportOnly = [];
-
-	/** @var PolicyArray */
-	private $snippets = [];
+	/** @phpstan-var PolicyArray */
+	private array $snippets = [];
 
 	/** @var array<int, string> */
-	private $currentSnippets = [];
+	private array $currentSnippets = [];
 
 	/** @var array<string, string> */
-	private $directives = [];
+	private array $directives = [];
 
 
-	public function __construct(GeneratorInterface $generator = null)
-	{
-		$this->nonceGenerator = $generator;
+	public function __construct(
+		private readonly ?GeneratorInterface $nonceGenerator = null,
+	) {
 	}
 
 
 	/**
-	 * @param PolicyArray $policy
-	 * @return self
+	 * @phpstan-param PolicyArray $policy
 	 */
 	public function setPolicy(array $policy): self
 	{
@@ -62,8 +55,7 @@ class Config
 
 
 	/**
-	 * @param PolicyArray $policy
-	 * @return self
+	 * @phpstan-param PolicyArray $policy
 	 */
 	public function setPolicyReportOnly(array $policy): self
 	{
@@ -75,8 +67,7 @@ class Config
 
 
 	/**
-	 * @param PolicyArray $snippets
-	 * @return self
+	 * @phpstan-param PolicyArray $snippets
 	 */
 	public function setSnippets(array $snippets): self
 	{
@@ -86,7 +77,7 @@ class Config
 
 
 	/**
-	 * @return PolicyArray
+	 * @phpstan-return PolicyArray
 	 */
 	public function getSnippets(): array
 	{
@@ -113,10 +104,7 @@ class Config
 
 
 	/**
-	 * @param string $presenter
-	 * @param string $action
-	 * @param PolicyArray $policy
-	 * @return string
+	 * @phpstan-param PolicyArray $policy
 	 */
 	private function getHeaderValue(string $presenter, string $action, array $policy): string
 	{
@@ -144,7 +132,7 @@ class Config
 	/**
 	 * @param array<string, array<int, string>> $currentPolicy
 	 * @param array<int, string> $parentKeys
-	 * @param PolicyArray $policy
+	 * @phpstan-param PolicyArray $policy
 	 * @return array<string, array<int, string>>
 	 */
 	private function mergeExtends(array $currentPolicy, array $parentKeys, array $policy): array
@@ -170,10 +158,7 @@ class Config
 
 
 	/**
-	 * @param string $presenter
-	 * @param string $action
-	 * @param PolicyArray $policy
-	 * @return string
+	 * @phpstan-param PolicyArray $policy
 	 */
 	private function findConfigKey(string $presenter, string $action, array $policy): string
 	{
@@ -190,7 +175,6 @@ class Config
 
 
 	/**
-	 * @param string $name
 	 * @param array<int, string> $sources
 	 */
 	private function addDirective(string $name, array $sources): void

--- a/tests/ConfigExtensionTest.phpt
+++ b/tests/ConfigExtensionTest.phpt
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Spaze\ContentSecurityPolicy\Bridges\Nette;
 
-use Nette\Configurator;
+use Nette\Bootstrap\Configurator;
 use Spaze\ContentSecurityPolicy\Config as CspConfig;
 use Tester\Assert;
 use Tester\Environment;
@@ -32,7 +32,7 @@ class ConfigExtensionTest extends TestCase
 	{
 		$configurator = new Configurator();
 		$configurator->setTempDirectory($this->tempDir);
-		$configurator->addParameters(['appDir' => __DIR__]);
+		$configurator->addStaticParameters(['appDir' => __DIR__]);
 		$configurator->addConfig($config);
 		$container = $configurator->createContainer();
 		return $container->getByType(CspConfig::class);

--- a/tests/ConfigExtensionTest.phpt
+++ b/tests/ConfigExtensionTest.phpt
@@ -18,11 +18,8 @@ Environment::setup();
 class ConfigExtensionTest extends TestCase
 {
 
-	/** @var string */
-	public $tempDir = __DIR__ . '/../temp/tests';
-
-	/** @var CspConfig */
-	private $cspConfig;
+	public string $tempDir = __DIR__ . '/../temp/tests';
+	private CspConfig $cspConfig;
 
 
 	protected function setUp(): void
@@ -42,7 +39,7 @@ class ConfigExtensionTest extends TestCase
 	}
 
 
-	protected function tearDown()
+	protected function tearDown(): void
 	{
 		Helpers::purge($this->tempDir);
 	}

--- a/tests/ConfigTest.phpt
+++ b/tests/ConfigTest.phpt
@@ -15,23 +15,17 @@ Environment::setup();
 class ConfigTest extends TestCase
 {
 
-	/** @var GeneratorInterface */
-	private $nonceGenerator;
+	private GeneratorInterface $nonceGenerator;
 
 
 	public function __construct()
 	{
 		$this->nonceGenerator = new class implements GeneratorInterface {
 
-			/** @var string */
-			private $random;
+			private string $random;
 
 
-			/**
-			 * @param string $random
-			 * @return GeneratorInterface
-			 */
-			public function setRandom($random): GeneratorInterface
+			public function setRandom(string $random): GeneratorInterface
 			{
 				$this->random = $random;
 				return $this;
@@ -47,14 +41,14 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetDefaultKey()
+	public function testGetDefaultKey(): void
 	{
 		$config = new Config();
 		Assert::same('*', $config->getDefaultKey());
 	}
 
 
-	public function testGetHeaderDefaultKeys()
+	public function testGetHeaderDefaultKeys(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -67,7 +61,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderDefaultAction()
+	public function testGetHeaderDefaultAction(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -80,7 +74,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeader()
+	public function testGetHeader(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -94,7 +88,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderReportOnly()
+	public function testGetHeaderReportOnly(): void
 	{
 		$config = new Config();
 		$config->setPolicyReportOnly([
@@ -107,7 +101,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderBoth()
+	public function testGetHeaderBoth(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -126,7 +120,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderModule()
+	public function testGetHeaderModule(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -139,7 +133,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderDefaultModule()
+	public function testGetHeaderDefaultModule(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -156,7 +150,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderDefaultActionWithSnippets()
+	public function testGetHeaderDefaultActionWithSnippets(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -175,7 +169,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderInheritance()
+	public function testGetHeaderInheritance(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -193,7 +187,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderDeepInheritance()
+	public function testGetHeaderDeepInheritance(): void
 	{
 		$config = new Config();
 		$config->setPolicy([
@@ -215,7 +209,7 @@ class ConfigTest extends TestCase
 	}
 
 
-	public function testGetHeaderWithNonceDirective()
+	public function testGetHeaderWithNonceDirective(): void
 	{
 		$random = 'https://xkcd.com/221/';
 		$config = new Config($this->nonceGenerator->setRandom($random));


### PR DESCRIPTION
- Require PHP 8.2 and newest dependencies
- Add types, remove unneeded docblocks
- Replace deprecated classes and methods