### PR TITLE
Accept a fully-qualified action (`Presenter:action`) as one param instead of presenter and action separated

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -88,29 +88,29 @@ class Config
 	/**
 	 * Get Content-Security-Policy header value.
 	 */
-	public function getHeader(string $presenter, string $action): string
+	public function getHeader(string $fullyQualifiedAction): string
 	{
-		return $this->getHeaderValue($presenter, $action, $this->policy);
+		return $this->getHeaderValue($fullyQualifiedAction, $this->policy);
 	}
 
 
 	/**
 	 * Get Content-Security-Policy-Report-Only header value.
 	 */
-	public function getHeaderReportOnly(string $presenter, string $action): string
+	public function getHeaderReportOnly(string $fullyQualifiedAction): string
 	{
-		return $this->getHeaderValue($presenter, $action, $this->policyReportOnly);
+		return $this->getHeaderValue($fullyQualifiedAction, $this->policyReportOnly);
 	}
 
 
 	/**
 	 * @phpstan-param PolicyArray $policy
 	 */
-	private function getHeaderValue(string $presenter, string $action, array $policy): string
+	private function getHeaderValue(string $fullyQualifiedAction, array $policy): string
 	{
 		$this->directives = [];
 
-		$configKey = $this->findConfigKey($presenter, $action, $policy);
+		$configKey = $this->findConfigKey($fullyQualifiedAction, $policy);
 		if (isset($policy[$configKey][self::EXTENDS_KEY])) {
 			$currentPolicy = $this->mergeExtends($policy[$configKey], $policy[$configKey][self::EXTENDS_KEY], $policy);
 		} else {
@@ -160,10 +160,9 @@ class Config
 	/**
 	 * @phpstan-param PolicyArray $policy
 	 */
-	private function findConfigKey(string $presenter, string $action, array $policy): string
+	private function findConfigKey(string $fullyQualifiedAction, array $policy): string
 	{
-		$parts = explode(':', strtolower($presenter));
-		$parts[] = strtolower($action);
+		$parts = explode(':', strtolower(trim($fullyQualifiedAction, ':')));
 		for ($i = count($parts) - 1; $i >= 0; $i--) {
 			if (isset($policy[implode(self::KEY_SEPARATOR, $parts)])) {
 				break;
@@ -198,7 +197,7 @@ class Config
 	 */
 	public function getDefaultKey(): string
 	{
-		return self::DEFAULT_KEY;
+		return self::DEFAULT_KEY . ':' . self::DEFAULT_KEY;
 	}
 
 }

--- a/tests/ConfigExtensionTest.phpt
+++ b/tests/ConfigExtensionTest.phpt
@@ -55,7 +55,7 @@ class ConfigExtensionTest extends TestCase
 	{
 		$this->cspConfig->addSnippet('ga');
 		Assert::noError(function (): void {
-			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://www.google-analytics.com', $this->cspConfig->getHeader('Foo', 'bar'));
+			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://www.google-analytics.com', $this->cspConfig->getHeader(':Foo:bar'));
 		});
 	}
 
@@ -64,7 +64,7 @@ class ConfigExtensionTest extends TestCase
 	{
 		$this->cspConfig->addSnippet('ga');
 		Assert::noError(function (): void {
-			Assert::same("child-src foo bar; style-src foo bar; script-src 'none'; img-src https://www.google-analytics.com", $this->cspConfig->getHeader('Bar', 'foo'));
+			Assert::same("child-src foo bar; style-src foo bar; script-src 'none'; img-src https://www.google-analytics.com", $this->cspConfig->getHeader('Bar:foo:'));
 		});
 	}
 
@@ -73,7 +73,7 @@ class ConfigExtensionTest extends TestCase
 	{
 		$this->cspConfig->addSnippet('ga');
 		Assert::noError(function (): void {
-			Assert::same("child-src foo bar; style-src foo bar; script-src foo bar 'self'; img-src https://www.google-analytics.com", $this->cspConfig->getHeader('Waldo', 'fred'));
+			Assert::same("child-src foo bar; style-src foo bar; script-src foo bar 'self'; img-src https://www.google-analytics.com", $this->cspConfig->getHeader(':Waldo:fred:'));
 		});
 	}
 
@@ -82,7 +82,7 @@ class ConfigExtensionTest extends TestCase
 	{
 		$this->cspConfig->addSnippet('ga-override');
 		Assert::noError(function (): void {
-			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://www.google-analytics.com https://ga.example', $this->cspConfig->getHeader('Foobar', 'baz'));
+			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://www.google-analytics.com https://ga.example', $this->cspConfig->getHeader('Foobar:baz'));
 		});
 	}
 
@@ -91,7 +91,7 @@ class ConfigExtensionTest extends TestCase
 	{
 		$this->cspConfig->addSnippet('ga');
 		Assert::noError(function (): void {
-			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://example.com https://www.google-analytics.com', $this->cspConfig->getHeader('Foobar', 'baz'));
+			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar; img-src https://example.com https://www.google-analytics.com', $this->cspConfig->getHeader('Foobar:baz'));
 		});
 	}
 
@@ -99,7 +99,7 @@ class ConfigExtensionTest extends TestCase
 	public function testConfigNoReportOnly(): void
 	{
 		Assert::noError(function (): void {
-			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar', $this->cspConfig->getHeader('Foo', 'bar'));
+			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar', $this->cspConfig->getHeader('Foo:bar'));
 			Assert::same('', $this->cspConfig->getHeaderReportOnly('Foo', 'bar'));
 		});
 	}
@@ -110,8 +110,8 @@ class ConfigExtensionTest extends TestCase
 		$cspConfig = $this->getService(__DIR__ . '/config-with-report-only.neon');
 		$this->cspConfig->addSnippet('ga');
 		Assert::noError(function () use ($cspConfig): void {
-			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar', $cspConfig->getHeader('Foo', 'bar'));
-			Assert::same('form-action foobar; script-src waldo quux', $cspConfig->getHeaderReportOnly('Foo', 'bar'));
+			Assert::same('child-src foo bar; style-src foo bar; script-src foo bar', $cspConfig->getHeader('Foo:bar'));
+			Assert::same('form-action foobar; script-src waldo quux', $cspConfig->getHeaderReportOnly('Foo:bar'));
 		});
 	}
 

--- a/tests/ConfigTest.phpt
+++ b/tests/ConfigTest.phpt
@@ -28,7 +28,7 @@ class ConfigTest extends TestCase
 
 	public function testGetDefaultKey(): void
 	{
-		Assert::same('*', $this->config->getDefaultKey());
+		Assert::same('*:*', $this->config->getDefaultKey());
 	}
 
 
@@ -40,7 +40,7 @@ class ConfigTest extends TestCase
 				'img-src' => ['https://example.com'],
 			],
 		]);
-		Assert::same("default-src 'none'; img-src https://example.com", $this->config->getHeader('Foo', 'bar'));
+		Assert::same("default-src 'none'; img-src https://example.com", $this->config->getHeader(':Foo:bar'));
 	}
 
 
@@ -52,7 +52,7 @@ class ConfigTest extends TestCase
 				'img-src' => ['https://foo.example.com'],
 			],
 		]);
-		Assert::same("default-src 'none'; img-src https://foo.example.com", $this->config->getHeader('Foo', 'bar'));
+		Assert::same("default-src 'none'; img-src https://foo.example.com", $this->config->getHeader('Foo:bar'));
 	}
 
 
@@ -64,7 +64,7 @@ class ConfigTest extends TestCase
 				'img-src' => ['https://foobar.example.com'],
 			],
 		]);
-		Assert::same("default-src 'none'; img-src https://foobar.example.com", $this->config->getHeader('Foo', 'bar'));
+		Assert::same("default-src 'none'; img-src https://foobar.example.com", $this->config->getHeader(':Foo:bar:'));
 		Assert::same('', $this->config->getHeaderReportOnly('Foo', 'bar'));
 	}
 
@@ -77,7 +77,7 @@ class ConfigTest extends TestCase
 			],
 		]);
 		Assert::same('', $this->config->getHeader('Foo', 'bar'));
-		Assert::same("default-src 'none'", $this->config->getHeaderReportOnly('Foo', 'bar'));
+		Assert::same("default-src 'none'", $this->config->getHeaderReportOnly(':Foo:bar'));
 	}
 
 
@@ -94,8 +94,8 @@ class ConfigTest extends TestCase
 				'default-src' => ["'none'"],
 			],
 		]);
-		Assert::same("default-src 'none'; img-src https://foobar.example.com", $this->config->getHeader('Foo', 'bar'));
-		Assert::same("default-src 'none'", $this->config->getHeaderReportOnly('Foo', 'bar'));
+		Assert::same("default-src 'none'; img-src https://foobar.example.com", $this->config->getHeader('Foo:bar:'));
+		Assert::same("default-src 'none'", $this->config->getHeaderReportOnly(':Foo:bar'));
 	}
 
 
@@ -107,7 +107,7 @@ class ConfigTest extends TestCase
 				'img-src' => ['https://foobar.example.com'],
 			],
 		]);
-		Assert::same("default-src 'none'; img-src https://foobar.example.com", $this->config->getHeader('Foo:Foo', 'bar'));
+		Assert::same("default-src 'none'; img-src https://foobar.example.com", $this->config->getHeader(':Foo:Foo:bar'));
 	}
 
 
@@ -123,7 +123,7 @@ class ConfigTest extends TestCase
 				'img-src' => 'https://foobar.example.com',
 			],
 		]);
-		Assert::same("default-src 'none'; img-src https://default.example.com", $this->config->getHeader('Waldo:Foo', 'bar'));
+		Assert::same("default-src 'none'; img-src https://default.example.com", $this->config->getHeader(':Waldo:Foo:bar'));
 	}
 
 
@@ -141,7 +141,7 @@ class ConfigTest extends TestCase
 				'script-src' => ['https://www.google-analytics.com'],
 			],
 		]);
-		Assert::same("default-src 'none'; img-src https://foo.example.com https://www.google-analytics.com; script-src https://www.google-analytics.com", $this->config->addSnippet('ga')->getHeader('Foo', 'bar'));
+		Assert::same("default-src 'none'; img-src https://foo.example.com https://www.google-analytics.com; script-src https://www.google-analytics.com", $this->config->addSnippet('ga')->getHeader(':Foo:bar'));
 	}
 
 
@@ -158,7 +158,7 @@ class ConfigTest extends TestCase
 				'img-src' => ['https://extends.example.com'],
 			],
 		]);
-		Assert::same("default-src 'self' https://extends.example.com; img-src https://default.example.com https://extends.example.com", $this->config->getHeader('Foo', 'bar'));
+		Assert::same("default-src 'self' https://extends.example.com; img-src https://default.example.com https://extends.example.com", $this->config->getHeader(':Foo:bar'));
 	}
 
 
@@ -179,7 +179,7 @@ class ConfigTest extends TestCase
 				'connect-src' => ['https://extends.example.com'],
 			],
 		]);
-		Assert::same("default-src 'self' https://extends.example.com; img-src https://default.example.com https://extends.example.com; connect-src https://extends.example.com", $this->config->getHeader('Bar', 'baz'));
+		Assert::same("default-src 'self' https://extends.example.com; img-src https://default.example.com https://extends.example.com; connect-src https://extends.example.com", $this->config->getHeader(':Bar:baz'));
 	}
 
 
@@ -191,7 +191,7 @@ class ConfigTest extends TestCase
 				'style-src' => ['https://foobar.example.com'],
 			],
 		]);
-		Assert::same("script-src 'self' 'nonce-" . self::RANDOM . "'; style-src https://foobar.example.com", $this->config->getHeader('Foo', 'bar'));
+		Assert::same("script-src 'self' 'nonce-" . self::RANDOM . "'; style-src https://foobar.example.com", $this->config->getHeader(':Foo:bar'));
 	}
 
 }


### PR DESCRIPTION
This makes it easier in Nette framework because you can use `$presenter->getAction(true);` which always returns a string, unlike `$presenter->getName();` which returns a nullable string. This change is useful to reach higher PHPStan levels.