### PR TITLE
Add `Csp` prefix to classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you're using Nette Framework you can add the extension to your config file:
 
 ```neon
 extensions:
-    contentSecurityPolicy: Spaze\ContentSecurityPolicy\Bridges\Nette\ConfigExtension
+    contentSecurityPolicy: Spaze\ContentSecurityPolicy\Bridges\Nette\CspConfigExtension
 ```
 
 ### Example configuration

--- a/src/Bridges/Nette/CspConfigExtension.php
+++ b/src/Bridges/Nette/CspConfigExtension.php
@@ -8,7 +8,7 @@ use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use stdClass;
 
-class ConfigExtension extends CompilerExtension
+class CspConfigExtension extends CompilerExtension
 {
 
 	/** @var stdClass */
@@ -36,7 +36,7 @@ class ConfigExtension extends CompilerExtension
 	public function loadConfiguration(): void
 	{
 		$this->getContainerBuilder()->addDefinition($this->prefix('config'))
-			->setType('Spaze\ContentSecurityPolicy\Config')
+			->setType('Spaze\ContentSecurityPolicy\CspConfig')
 			->addSetup('setPolicy', [$this->config->policies])
 			->addSetup('setPolicyReportOnly', [$this->config->policiesReportOnly])
 			->addSetup('setSnippets', [$this->config->snippets]);

--- a/src/CspConfig.php
+++ b/src/CspConfig.php
@@ -9,7 +9,7 @@ use Spaze\NonceGenerator\Nonce;
 /**
  * @phpstan-type PolicyArray array<string, array<string, array<int, string>>>
  */
-class Config
+class CspConfig
 {
 
 	private const DEFAULT_KEY = '*';

--- a/tests/CspConfigExtensionTest.phpt
+++ b/tests/CspConfigExtensionTest.phpt
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace Spaze\ContentSecurityPolicy\Bridges\Nette;
 
 use Nette\Bootstrap\Configurator;
-use Spaze\ContentSecurityPolicy\Config as CspConfig;
+use Spaze\ContentSecurityPolicy\CspConfig;
 use Tester\Assert;
 use Tester\Environment;
 use Tester\Helpers;
@@ -15,7 +15,7 @@ require __DIR__ . '/../vendor/autoload.php';
 Environment::setup();
 
 /** @testCase */
-class ConfigExtensionTest extends TestCase
+class CspConfigExtensionTest extends TestCase
 {
 
 	public string $tempDir = __DIR__ . '/../temp/tests';
@@ -117,4 +117,4 @@ class ConfigExtensionTest extends TestCase
 
 }
 
-(new ConfigExtensionTest())->run();
+(new CspConfigExtensionTest())->run();

--- a/tests/CspConfigTest.phpt
+++ b/tests/CspConfigTest.phpt
@@ -12,17 +12,17 @@ require __DIR__ . '/../vendor/autoload.php';
 Environment::setup();
 
 /** @testCase */
-class ConfigTest extends TestCase
+class CspConfigTest extends TestCase
 {
 
 	private const RANDOM = 'https://xkcd.com/221/';
 
-	private Config $config;
+	private CspConfig $config;
 
 
 	protected function setUp(): void
 	{
-		$this->config = new Config(new Nonce(self::RANDOM));
+		$this->config = new CspConfig(new Nonce(self::RANDOM));
 	}
 
 
@@ -196,4 +196,4 @@ class ConfigTest extends TestCase
 
 }
 
-(new ConfigTest())->run();
+(new CspConfigTest())->run();

--- a/tests/config-with-report-only.neon
+++ b/tests/config-with-report-only.neon
@@ -1,5 +1,5 @@
 extensions:
-	contentSecurityPolicy: Spaze\ContentSecurityPolicy\Bridges\Nette\ConfigExtension
+	contentSecurityPolicy: Spaze\ContentSecurityPolicy\Bridges\Nette\CspConfigExtension
 	nonceGenerator: Spaze\NonceGenerator\Bridges\Nette\GeneratorExtension
 
 contentSecurityPolicy:

--- a/tests/config.neon
+++ b/tests/config.neon
@@ -1,5 +1,5 @@
 extensions:
-	contentSecurityPolicy: Spaze\ContentSecurityPolicy\Bridges\Nette\ConfigExtension
+	contentSecurityPolicy: Spaze\ContentSecurityPolicy\Bridges\Nette\CspConfigExtension
 	nonceGenerator: Spaze\NonceGenerator\Bridges\Nette\GeneratorExtension
 
 contentSecurityPolicy:


### PR DESCRIPTION
Saves some aliases because `Config` is too generic.