### PR TITLE
Support PHP 8.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         php-version:
           - "8.2"
+          - "8.3"
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
~~Waiting for nette/bootstrap to support PHP 8.3~~ Supported in [3.2.1](https://github.com/nette/bootstrap/releases/tag/v3.2.1).